### PR TITLE
DurabilityTracker fixes

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/DurabilityManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/DurabilityManager.cs
@@ -30,14 +30,11 @@
 
 #endregion
 
-using System;
 using System.Collections.Concurrent;
 using ClassicUO.Game.Data;
-using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Gumps;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 

--- a/src/ClassicUO.Client/Game/Managers/ObjectPropertiesListManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ObjectPropertiesListManager.cs
@@ -31,6 +31,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ClassicUO.Network;
 
 namespace ClassicUO.Game.Managers
@@ -39,7 +40,7 @@ namespace ClassicUO.Game.Managers
     {
         private readonly Dictionary<uint, ItemProperty> _itemsProperties = new Dictionary<uint, ItemProperty>();
 
-        public delegate void OPLOnReceiveEvent(OPLEventArgs _args);
+        public delegate void OPLOnReceiveEvent(OPLEventArgs args);
         public event OPLOnReceiveEvent OPLOnReceive;
 
         public void Add(uint serial, uint revision, string name, string data, int namecliloc)

--- a/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
@@ -133,7 +133,19 @@ namespace ClassicUO.Game.UI.Gumps
             GumpsLoader.Instance.GetGumpTexture((uint)DurabilityColors.RED, out var barBounds);
             var startY = 0;
 
-            foreach (var durability in World.DurabilityManager.Durabilties.OrderBy(d => d.Percentage))
+            try
+            {
+                var lala = World.DurabilityManager?.Durabilities ?? new List<DurabiltyProp>();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+
+            var items = World.DurabilityManager?.Durabilities ?? new List<DurabiltyProp>();
+            
+            foreach (var durability in items.OrderBy(d => d.Percentage))
             {
                 if (durability.MaxDurabilty <= 0)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
@@ -133,16 +133,6 @@ namespace ClassicUO.Game.UI.Gumps
             GumpsLoader.Instance.GetGumpTexture((uint)DurabilityColors.RED, out var barBounds);
             var startY = 0;
 
-            try
-            {
-                var lala = World.DurabilityManager?.Durabilities ?? new List<DurabiltyProp>();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                throw;
-            }
-
             var items = World.DurabilityManager?.Durabilities ?? new List<DurabiltyProp>();
             
             foreach (var durability in items.OrderBy(d => d.Percentage))


### PR DESCRIPTION
Durability tracker sometimes crashed the game on startup, it also did not show all the Items in the list during startup.
This was due to the multiple running threads on the update function.

Changed this to a ConcurrentDictionary instead, as well as made special fixed for the Dictionary being Null, this should not happen any more, but rather safe than sorry.

Also fixed minor spelling misstakes and did some cleanup