### PR TITLE
Feature/backpack dbl click equip

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -342,6 +342,11 @@ namespace ClassicUO.Game
                     {
                         g.SetInScreen();
                         g.BringOnTop();
+                        if (UIManager.MouseOverControl != null)
+                        {
+                            UIManager.OnMouseDoubleClick(MouseButtonType.Left);
+                            return;
+                        }
                     }
                     Socket.Send_DoubleClick(serial);
                 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -916,9 +916,28 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     GameActions.GrabItem(_item, _item.Amount);
                 }
-                else
+                else if (!_item.IsDestroyed && container == World.Player.FindItemByLayer(Layer.Backpack))
                 {
-                    GameActions.DoubleClick(LocalSerial);
+                    if (_item.ItemData.IsWearable && !_item.ItemData.IsContainer)
+                    {
+                        Item equipment = World.Player.FindItemByLayer((Layer)_item.ItemData.Layer);
+                        if (equipment != null)
+                        {
+                            GameActions.GrabItem(equipment.Serial, 0, container.Serial);
+                            GameActions.DoubleClickQueued(container.Serial);
+                            Mouse.CancelDoubleClick = true;
+                            return;
+                        }
+                        GameActions.PickUp(_item.Serial, 0, 0, 1);                        
+                        Task.Delay(Mouse.MOUSE_DELAY_DOUBLE_CLICK).Wait();
+                        GameActions.Equip();
+                        Mouse.CancelDoubleClick = true;
+                        return;
+                    }
+                    else
+                    {
+                        GameActions.DoubleClick(LocalSerial);
+                    }                        
                 }
                 e.Result = true;
             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -916,28 +916,25 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     GameActions.GrabItem(_item, _item.Amount);
                 }
-                else if (!_item.IsDestroyed && container == World.Player.FindItemByLayer(Layer.Backpack))
+                else if (!_item.IsDestroyed && container == World.Player.FindItemByLayer(Layer.Backpack) && _item.ItemData.IsWearable && !_item.ItemData.IsContainer)
                 {
-                    if (_item.ItemData.IsWearable && !_item.ItemData.IsContainer)
+                    Item equipment = World.Player.FindItemByLayer((Layer)_item.ItemData.Layer);
+                    if (equipment != null)
                     {
-                        Item equipment = World.Player.FindItemByLayer((Layer)_item.ItemData.Layer);
-                        if (equipment != null)
-                        {
-                            GameActions.GrabItem(equipment.Serial, 0, container.Serial);
-                            GameActions.DoubleClickQueued(container.Serial);
-                            Mouse.CancelDoubleClick = true;
-                            return;
-                        }
-                        GameActions.PickUp(_item.Serial, 0, 0, 1);                        
-                        Task.Delay(Mouse.MOUSE_DELAY_DOUBLE_CLICK).Wait();
-                        GameActions.Equip();
+                        GameActions.GrabItem(equipment.Serial, 0, container.Serial);
+                        GameActions.DoubleClickQueued(container.Serial);
                         Mouse.CancelDoubleClick = true;
                         return;
                     }
-                    else
-                    {
-                        GameActions.DoubleClick(LocalSerial);
-                    }                        
+                    GameActions.PickUp(_item.Serial, 0, 0, 1);
+                    Task.Delay(Mouse.MOUSE_DELAY_DOUBLE_CLICK).Wait();
+                    GameActions.Equip();
+                    Mouse.CancelDoubleClick = true;
+                    return;
+                }
+                else
+                {
+                    GameActions.DoubleClick(LocalSerial);
                 }
                 e.Result = true;
             }


### PR DESCRIPTION
Tried to implement inline Task.Delay between Unequip slot and Equip Item, however the state between local and server were not synced and kept getting "Please wait to perform another action".

I went ahead with the DoubleClickQueued. Future improvement maybe not to rely on the MouseOverControl but store a Control reference on the GridContainerGump that was initial double clicked.

![dblclick_equip](https://github.com/bittiez/TazUO/assets/127065794/fa40cc50-1523-4cae-84c7-f68c08664dd7)
