### PR TITLE
fix weird lines

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>ClassicUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>3.23.0</AssemblyVersion>
-    <FileVersion>3.23.0</FileVersion>
+    <AssemblyVersion>3.23.1</AssemblyVersion>
+    <FileVersion>3.23.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -823,7 +823,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 SolidColorTextureCache.GetTexture(Color.White),
                 new Vector2(x + 1, y + 1),
-                new Rectangle(x, y, Math.Min((int)((Width - 1) * data.Item2), Width - 1), height - 1),
+                new Rectangle(x, y, Math.Min((int)((Width - 1) * data.Item2), Width - 1), height),
                 data.Item1
             );
             nY = y + height;

--- a/src/ClassicUO.Client/Game/UI/Gumps/VersionHistory.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/VersionHistory.cs
@@ -8,6 +8,9 @@ namespace ClassicUO.Game.UI.Gumps
     internal class VersionHistory : Gump
     {
         private static string[] updateTexts = {
+            "/c[white][3.23.1]/cd\n" +
+                "- Fixed Weird lines if show Nameplate",
+
             "/c[white][3.23.0]/cd\n" +
                 "- Nameplate healthbar poison and invul/paralyzed colors from Elderwyn\n" +
                 "- Target indiciator option from original client from Elderwyn\n" +


### PR DESCRIPTION
We adjusted the nameoverplate, because when it appeared on the screen, it created a line, now it no longer creates

https://discord.com/channels/1087124353155608617/1273393942662086656/1273393942662086656