### PR TITLE
Update tuo-deploy.yml

### DIFF
--- a/.github/workflows/tuo-deploy.yml
+++ b/.github/workflows/tuo-deploy.yml
@@ -61,17 +61,8 @@ jobs:
     - name: Restore NuGet Packages
       run: dotnet restore ${{ env.CUO_PROJECT_PATH }}
 
-    - name: Build ManifestCreator
-      run: dotnet build tools/ManifestCreator/ManifestCreator.csproj -c Release
-
     - name: Build
       run: dotnet publish ${{ env.CUO_PROJECT_PATH }} -c Release -o ${{ env.CUO_OUTPUT_PATH }} -p:IS_DEV_BUILD=true
-      
-    - name: Create manifest
-      run: |
-        dotnet run --project tools/ManifestCreator/ManifestCreator.csproj "${{ env.CUO_OUTPUT_PATH }}" "unix-auto" "${{ runner.os }}${{ env.CUO_ZIP_NAME }}"
-        mkdir upload
-        mv manifest.xml upload
       
     - name: Create package
       uses: thedoctor0/zip-release@master


### PR DESCRIPTION
The manifest is just for ClassicUO's updater, we don't need it and it's stopping this action from completing on Mac so let's just remove it

Solves #234 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined deployment process by removing unnecessary manifest creation steps.
	- Focused on building and packaging the main project for more efficient releases.
  
- **Bug Fixes**
	- Updated the checkout action to the latest version for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->