### PR TITLE
Fix skill progress bars

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -410,6 +410,7 @@ namespace ClassicUO.Game.Scenes
 
             CommandManager.UnRegisterAll();
             Weather.Reset();
+            SkillProgressBar.QueManager.Reset();
             UIManager.Clear();
             World.Clear();
             ChatManager.Clear();


### PR DESCRIPTION
This PR fixes all the issues with the skill progress bars

- Won't show on login screen after logging out
- Correctly timed, instead of sometimes big delays between them
- Correctly shows progress bar if value is > cap
- Correctly manages the que to get the next skill update