### PR TITLE
Fix & symbol in json save file

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -186,7 +186,7 @@ namespace ClassicUO.Game.UI.Controls
                 else
                     Option.NameOverheadOptionFlags &= ~(int)optionFlag;
 
-                if (NameOverHeadManager.LastActiveNameOverheadOption == Option.Name)
+                if (NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == Option.Name)
                     NameOverHeadManager.ActiveOverheadOptions = (NameOverheadOptions)Option.NameOverheadOptionFlags;
             };
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -6348,7 +6348,7 @@ namespace ClassicUO.Game.UI.Gumps
                     else
                         Option.NameOverheadOptionFlags &= ~(int)optionFlag;
 
-                    if (NameOverHeadManager.LastActiveNameOverheadOption == Option.Name)
+                    if (NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == Option.Name)
                         NameOverHeadManager.ActiveOverheadOptions = (NameOverheadOptions)Option.NameOverheadOptionFlags;
                 });
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -144,7 +144,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             foreach (var button in _overheadButtons)
             {
-                button.IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == button.Text;
+                button.IsChecked = NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == button.Text;
             }
         }
 
@@ -186,7 +186,7 @@ namespace ClassicUO.Game.UI.Gumps
                 )
                 {
                     Y = 20 * index + 44,
-                    IsChecked = NameOverHeadManager.LastActiveNameOverheadOption == option.Name,
+                    IsChecked = NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == option.Name,
                 }
             );
 


### PR DESCRIPTION
This is a fix for nameplate options with & in the name not saving correctly

The json serialiizer saves `&` as `\u0026`, when it's loaded back in it is loaded as `\u0026` instead of `&`