### PR TITLE
Add dps-counter

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -320,6 +320,7 @@ namespace ClassicUO.Configuration
             public string SingleClickForSpellIcons { get; set; } = "Single click for spell icons";
             public string ShowBuffDurationOnOldStyleBuffBar { get; set; } = "Show buff duration on old style buff bar";
             public string EnableFastSpellHotkeyAssigning { get; set; } = "Enable fast spell hotkey assigning";
+            public string EnableDPSCounter { get; set; } = "Enable damage-taken DPS counter with damage numbers";
             public string TooltipFastSpellAssign { get; set; } = "Ctrl + Alt + Click a spell icon the open a gump to set a hotkey";
             public string InnocentColor { get; set; } = "Innocent color";
             public string BeneficialSpell { get; set; } = "Beneficial spell";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -420,6 +420,8 @@ namespace ClassicUO.Configuration
         public ushort DamageHueAlly { get; set; } = 0x0030;
         public ushort DamageHueLastAttck { get; set; } = 0x1F;
         public ushort DamageHueOther { get; set; } = 0x0021;
+
+        public bool ShowDPS { get; set; } = true;
         #endregion
 
         #region GridHighlightingProps

--- a/src/ClassicUO.Client/Game/Data/MessageType.cs
+++ b/src/ClassicUO.Client/Game/Data/MessageType.cs
@@ -51,6 +51,7 @@ namespace ClassicUO.Game.Data
         Command = 15,
         Encoded = 0xC0,
         ChatSystem, //TazUO Addition, value unimportant
+        Damage, //TazUO Addition, value unimportant
         Party = 0xFF // This is a CUO assigned type, value is unimportant
     }
 }

--- a/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
@@ -112,12 +112,13 @@ namespace ClassicUO.Game.GameObjects
             TextObject text_obj = TextObject.Create();
 
             ushort hue = ProfileManager.CurrentProfile == null ? (ushort)0x0021 : ProfileManager.CurrentProfile.DamageHueOther;
-
+            string name = string.Empty;
             if (ReferenceEquals(Parent, World.Player))
                 hue = ProfileManager.CurrentProfile == null ? (ushort)0x0034 : ProfileManager.CurrentProfile.DamageHueSelf;
             else if (Parent is Mobile)
             {
                 Mobile _parent = (Mobile)Parent;
+                name = _parent.Name;
                 if (_parent.IsRenamable && _parent.NotorietyFlag != NotorietyFlag.Invulnerable && _parent.NotorietyFlag != NotorietyFlag.Enemy)
                     hue = ProfileManager.CurrentProfile == null ? (ushort)0x0033 : ProfileManager.CurrentProfile.DamageHuePet;
                 else if (_parent.NotorietyFlag == NotorietyFlag.Ally)
@@ -128,6 +129,8 @@ namespace ClassicUO.Game.GameObjects
             }
             string dps = ProfileManager.CurrentProfile.ShowDPS ? $" (DPS: {Parent.GetCurrentDPS()})" : string.Empty;
             text_obj.TextBox = new UI.Controls.TextBox(damage.ToString() + dps, ProfileManager.CurrentProfile.OverheadChatFont, ProfileManager.CurrentProfile.OverheadChatFontSize, ProfileManager.CurrentProfile.OverheadChatWidth, hue, align: FontStashSharp.RichText.TextHorizontalAlignment.Center) { AcceptMouseInput = !ProfileManager.CurrentProfile.DisableMouseInteractionOverheadText };
+
+            World.Journal.Add(damage.ToString() + dps, hue, name, TextType.CLIENT, messageType: MessageType.Damage);
 
             text_obj.Time = Time.Ticks + 1500;
 

--- a/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
@@ -79,6 +79,8 @@ namespace ClassicUO.Game.GameObjects
         }
     }
 
+
+
     internal class OverheadDamage
     {
         private const int DAMAGE_Y_MOVING_TIME = 25;
@@ -97,6 +99,7 @@ namespace ClassicUO.Game.GameObjects
         public bool IsDestroyed { get; private set; }
         public bool IsEmpty => _messages.Count == 0;
 
+
         public void SetParent(GameObject parent)
         {
             Parent = parent;
@@ -104,6 +107,8 @@ namespace ClassicUO.Game.GameObjects
 
         public void Add(int damage)
         {
+            Parent.AddDamage(damage);
+
             TextObject text_obj = TextObject.Create();
 
             ushort hue = ProfileManager.CurrentProfile == null ? (ushort)0x0021 : ProfileManager.CurrentProfile.DamageHueOther;
@@ -121,8 +126,8 @@ namespace ClassicUO.Game.GameObjects
                 if (_parent.Serial == TargetManager.LastAttack)
                     hue = ProfileManager.CurrentProfile == null ? (ushort)0x1F : ProfileManager.CurrentProfile.DamageHueLastAttck;
             }
-
-            text_obj.TextBox = new UI.Controls.TextBox(damage.ToString(), ProfileManager.CurrentProfile.OverheadChatFont, ProfileManager.CurrentProfile.OverheadChatFontSize, ProfileManager.CurrentProfile.OverheadChatWidth, hue, align: FontStashSharp.RichText.TextHorizontalAlignment.Center) { AcceptMouseInput = !ProfileManager.CurrentProfile.DisableMouseInteractionOverheadText };
+            string dps = ProfileManager.CurrentProfile.ShowDPS ? $" (DPS: {Parent.GetCurrentDPS()})" : string.Empty;
+            text_obj.TextBox = new UI.Controls.TextBox(damage.ToString() + dps, ProfileManager.CurrentProfile.OverheadChatFont, ProfileManager.CurrentProfile.OverheadChatFontSize, ProfileManager.CurrentProfile.OverheadChatWidth, hue, align: FontStashSharp.RichText.TextHorizontalAlignment.Center) { AcceptMouseInput = !ProfileManager.CurrentProfile.DisableMouseInteractionOverheadText };
 
             text_obj.Time = Time.Ticks + 1500;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -1262,6 +1262,16 @@ namespace ClassicUO.Game.UI.Gumps
 
             PositionHelper.BlankLine();
 
+            options.Add(s = new SettingsOption(
+                "",
+                new CheckboxWithLabel(lang.GetCombatSpells.EnableDPSCounter, 0, profile.ShowDPS, (b) => { profile.ShowDPS = b; }),
+                mainContent.RightWidth,
+                PAGE.CombatSpells
+            ));
+            PositionHelper.PositionControl(s.FullControl);
+
+            PositionHelper.BlankLine();
+
             SettingsOption ss;
             options.Add(s = new SettingsOption(
                 "",

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -710,6 +710,9 @@ namespace ClassicUO.Game.UI.Gumps
                             case MessageType.Party:
                                 entryName = "Party";
                                 break;
+                            case MessageType.Damage:
+                                entryName = "Damage";
+                                break;
                         }
 
                         Add(entryName,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2a8aa699-3051-4be7-bc27-5d5d59a8fd32)
![image](https://github.com/user-attachments/assets/f15a831a-9b0d-442b-b743-828743797764)


Can be disabled under Options->Combat and Spells

And this is damage-taken dps, shown with all damage numbers, the client doesn't know who dealt the damage so a damage-dealt dps isn't really possible without making assumptions of who dealt the damage.